### PR TITLE
check return code instead of stderr length to resolve promise

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,7 @@ module.exports = function openssl(params, options = { dir: '' }) {
         });
 
         openSSLProcess.on('close', (code) => {
-            if (stderr.length > 0) {
+            if (code !== 0) {
                 return reject(new Error(Buffer.concat(stderr)).toString())
             }
             return resolve(Buffer.concat(stdout));


### PR DESCRIPTION
OpenSSL might write some notices to stderr although the command was successful and the desired output has been written to stdout or file.

Check the return code to be non-zero resolves the promise resolve in this case.

For example the command `openssl genrsa` writes the following to _stderr_:
```text
Generating RSA private key, 2048 bit long modulus (2 primes)
............................+++++
....................................................................+++++
e is 65537 (0x010001)
```
and the key itself to _stdout_:
```text
-----BEGIN RSA PRIVATE KEY-----
...
-----END RSA PRIVATE KEY-----
```

That's expected behavior, however the promise gets rejected. Return code 0 is the better indicator in this case.